### PR TITLE
bg: custom process.env not in server.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ logs
 *.log
 npm-debug.log*
 yarn.lock
-# .env
+.env
 
 # Externals
 external/

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
  * Module dependencies.
  */
 
-const debug = require('debug')('sttp:server');
+require('dotenv').config();
+const debug = require('debug')('http:server');
 const http = require('http');
 const app = require('./server')
-require('dotenv').config();
 
 /**
  * Get port from environment and store in Express.


### PR DESCRIPTION
RabbitMQ was causing the app to crash because it was not seeing the `process.env.AMQP` variable.
This was caused by `dotenv` being required after `server.js` in `index.js` instead of before it